### PR TITLE
Core - Fix: Broadcast Smoke Sound Effect once instead of (amount of players) times

### DIFF
--- a/addons/core/functions/effects/fn_smoke.sqf
+++ b/addons/core/functions/effects/fn_smoke.sqf
@@ -20,13 +20,6 @@ params ["_unit", "_cigConfig"];
 
 if !(lifeState _unit in ["HEALTHY", "INJURED"]) exitWith {};
 
-
-private _sound = [_cigConfig >> QPVAR(smokeSound)] call CBA_fnc_getCfgDataRandom;
-
-if (isNil "_sound") then { _sound = selectRandom [QPVAR(smoke_3),QPVAR(smoke_4)] };
-
-[_unit, _sound, 15, true, false, true] call CBA_fnc_globalSay3d;
-
 [
     {
         params ["_unit", "_cigConfig"];

--- a/addons/core/functions/smoking/fn_smoking.sqf
+++ b/addons/core/functions/smoking/fn_smoking.sqf
@@ -43,9 +43,9 @@ switch (_itemType) do {
 ////////////////////////////////////////
 // Sound Effects
 ////////////////////////////////////////
-private _sound = [_cigConfig >> QPVAR(smokeSound)] call CBA_fnc_getCfgDataRandom;
+private _sound = (_itemConfig >> QPVAR(smokeSound)) call CBA_fnc_getCfgDataRandom;
 if (isNil "_sound") then { _sound = selectRandom [QPVAR(smoke_3),QPVAR(smoke_4)] };
-[_unit, _sound, 15, true, false, true] call CBA_fnc_globalSay3d;
+[_unit, _sound, 20, true, true, true] call CBA_fnc_globalSay3d;
 
 
 ////////////////////////////////////////

--- a/addons/core/functions/smoking/fn_smoking.sqf
+++ b/addons/core/functions/smoking/fn_smoking.sqf
@@ -41,6 +41,14 @@ switch (_itemType) do {
 
 
 ////////////////////////////////////////
+// Sound Effects
+////////////////////////////////////////
+private _sound = [_cigConfig >> QPVAR(smokeSound)] call CBA_fnc_getCfgDataRandom;
+if (isNil "_sound") then { _sound = selectRandom [QPVAR(smoke_3),QPVAR(smoke_4)] };
+[_unit, _sound, 15, true, false, true] call CBA_fnc_globalSay3d;
+
+
+////////////////////////////////////////
 // Fatigue
 ////////////////////////////////////////
 _unit setFatigue (getFatigue _unit + 0.01);

--- a/addons/core/functions/smoking/fn_smoking.sqf
+++ b/addons/core/functions/smoking/fn_smoking.sqf
@@ -118,7 +118,7 @@ if (_currentTime < 15) then {
 // Call Recursive Function
 ////////////////////////////////////////
 
-_timeoutCode = {
+private _timeoutCode = {
     params ["_unit","_currentTime","_currentItem","_itemType","_maxTime","_itemConfig"];
     if (  [_unit, _itemType, _currentItem, _currentTime, _maxTime] call FUNC(canKeepSmoking) ) then {
 
@@ -137,9 +137,9 @@ _timeoutCode = {
     };
 };
 
-_condition = { !((_this#0) getVariable [QPVAR(isSmoking), false]) };
+private _condition = { !((_this#0) getVariable [QPVAR(isSmoking), false]) };
 
-_statement = {
+private _statement = {
     params ["_unit","_currentTime","_currentItem","_itemType","_maxTime","_itemConfig"];
     [_unit, QEGVAR(anim,cig_out), 1] call FUNC(anim);
 


### PR DESCRIPTION
Global event raised from inside a global event bad. :harold:

On a server with 80 players, each individual smokepuff caused 80x80 = 6.400 requests for the smoke sound effect to be played.
Now if half of those players smoke, you end up with 40 smoke puffs every 3 ~ 30 seconds. 
This could cause somewhere from 50.000 up to 230.000 sound effect requests per minute.

Honestly supprised it wasnt noted by smaller servers.

Lesson: Dont code sleepdeprived